### PR TITLE
Quick fix for readme modal closing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 	@ViewChild(DatePickerDirective) private datepickerDirective:DatePickerDirective;
 
     public closeDatepicker(){
-        this.datepickerDirective.dismiss();
+        this.datepickerDirective.modal.dismiss();
     }
     
 ```


### PR DESCRIPTION
Changed Readme to correctly show how to close the datepicker from the class. 