### PR TITLE
Fix empty months and default date on disabled date

### DIFF
--- a/src/components/datepicker.component.ts
+++ b/src/components/datepicker.component.ts
@@ -762,6 +762,19 @@ export class DatePickerComponent {
                 }
             }
             this.tempDate = testDate;
+
+            let availableDates = this.DatepickerService.getMonthAvailableDays(testDate, this.config.disabledDates);
+
+            if (availableDates.length === 0) {
+                this.tempDate = testDate;
+                this.nextMonth();
+                return;
+            }
+            // if the current day is a disabled one, just take the first available day
+            if (-1 === availableDates.findIndex(date => date.getDate() === this.tempDate.getDate())) {
+                this.tempDate = availableDates[0];
+            }
+
             this.createDateList(this.tempDate);
         }
     }
@@ -791,6 +804,19 @@ export class DatePickerComponent {
                 }
             }
             this.tempDate = testDate;
+
+            let availableDates = this.DatepickerService.getMonthAvailableDays(testDate, this.config.disabledDates);
+
+            if (availableDates.length === 0) {
+                this.tempDate = testDate;
+                this.prevMonth();
+                return;
+            }
+            // if the current day is a disabled one, just take the last available day
+            if (-1 === availableDates.findIndex(date => date.getDate() === this.tempDate.getDate())) {
+                this.tempDate = availableDates[availableDates.length - 1];
+            }
+
             this.createDateList(this.tempDate);
         }
     }

--- a/src/services/datepicker.service.ts
+++ b/src/services/datepicker.service.ts
@@ -119,4 +119,26 @@ export class DateService {
 
         return dateList;
     }
+
+    /**
+     *
+     * @function getMonthAvailableDays - returns the list of available dates for the month of the current date
+     * @param {Date} currentDate - use to get the month for the list
+     * @param {Date[]} disabledDates - the disabled dates
+     * @returns {Date[]}
+     * @memberof DateService
+     */
+    public getMonthAvailableDays(currentDate: Date, disabledDates: Date[]): Date[] {
+      // get the disabled dates of the month
+      let disabledMonthDates = disabledDates.filter(date => date.getFullYear() === currentDate.getFullYear() && date.getMonth() === currentDate.getMonth());
+
+      let dateList = this.createDateList(currentDate);
+
+      // remove the empty dates
+      while (dateList.length > 0 && !dateList[0]) {
+          dateList.shift();
+      }
+
+      return dateList.filter(date => -1 === disabledMonthDates.findIndex(disabledDate => disabledDate.getDate() === date.getDate()));
+    }
 }


### PR DESCRIPTION
I found 2 bugs using the disabled dates : 

- If a month is completely disabled, the datepicker should skip this month when the user clicks next or previous. Otherwise, it will selected a date and if the user clicks OK, it will selected this disabled date.
- If the user clicks next or previous, the default selected day is the same as the previous month selected day. But if this day is a disabled one, then the user will be able to selected a disabled day. In this case, I selected the first day available if clicking next, the last day if clicking previous.

Here is a fix of these two bugs.

Cheers!

And thank you for this awesome Ionic component I use in a lot of my projects. :)
