### PR TITLE
Fix bug allowing the selection of a date after the max date when swit…

### DIFF
--- a/src/components/datepicker.component.ts
+++ b/src/components/datepicker.component.ts
@@ -752,8 +752,8 @@ export class DatePickerComponent {
         let maxTestDate: Date;
         if (this.config.max) {
             maxTestDate = new Date(this.config.max);
-            maxTestDate.setDate(0);
             maxTestDate.setMonth(maxTestDate.getMonth() + 1);
+            maxTestDate.setDate(0);
         }
         if (!maxTestDate || maxTestDate >= testDate) {
             if (maxTestDate && maxTestDate.getMonth() === testDate.getMonth()) {


### PR DESCRIPTION
Fix a bug that would allow the user to select a date later than the maximum possible date when switching to the next month.
This issue was brought up as the [issue #98](https://github.com/misha130/ion-datepicker/issues/98).