### PR TITLE
Fix for Issue #98

### DIFF
--- a/src/components/datepicker.component.ts
+++ b/src/components/datepicker.component.ts
@@ -751,9 +751,7 @@ export class DatePickerComponent {
         }
         let maxTestDate: Date;
         if (this.config.max) {
-            maxTestDate = new Date(this.config.max);
-            maxTestDate.setMonth(maxTestDate.getMonth() + 1);
-            maxTestDate.setDate(0);
+            maxTestDate = new Date(this.config.max.getFullYear(), this.config.max.getMonth() + 1, 0);
         }
         if (!maxTestDate || maxTestDate >= testDate) {
             if (maxTestDate && maxTestDate.getMonth() === testDate.getMonth()) {


### PR DESCRIPTION
I've thought about my previous fix some more and realized that a problem was remaining in some cases, even though it did behave better.

This fix should seal the problem of issue #98 by always setting `maxTestDate` to the last day of the corresponding month as opposed to the last day of the next month in some cases.